### PR TITLE
hooks: cleanup harder

### DIFF
--- a/hooks/600-no-debian.chroot
+++ b/hooks/600-no-debian.chroot
@@ -11,7 +11,8 @@ install -m755 -d usr/share/snappy
 dpkg -l > usr/share/snappy/dpkg.list
 
 # dpkg-deb and dpkg purposefully left behind
-chroot . dpkg --purge --force-depends apt libapt-pkg5.0
+dpkg --purge --force-depends apt libapt-pkg5.0 debconf
+
 rm -r \
         var/lib/dpkg \
         var/log/apt

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -72,5 +72,13 @@ rm -rf /etc/alternatives
 # no permanet journal
 rm -rf /var/log/journal
 
+# clean leftovers from the build
+rm /var/log/*
+
+# no "local" on core18
+rm -rf -- /var/local /usr/local
+
+# no debconf
+rm -rf /var/cache/debconf
 
 # FIXME: make /etc/lsb-release point to ../usr/lib/lsb-release


### PR DESCRIPTION
Remove debconf as well ensure /var is a bit cleaner.