### PR TITLE
hooks: ensure UID/GID never change on the core image (and kill _apt)

### DIFF
--- a/hooks/600-no-debian.chroot
+++ b/hooks/600-no-debian.chroot
@@ -35,3 +35,6 @@ rm -f var/log/bootstrap.log \
 rm -f /etc/cron.daily/dpkg \
       /etc/cron.daily/passwd
     
+
+# and kill the _apt user
+deluser _apt

--- a/hooks/990-ensure-uids-gids.chroot
+++ b/hooks/990-ensure-uids-gids.chroot
@@ -1,0 +1,85 @@
+#!/bin/bash -x
+
+set -e
+
+# We *must* ensure that uid/gid never changes in the core image because
+# the UIDs will (potentially) leak out into the filesystem and /etc/passwd
+# and friends are part of the readonly part of the core snap so they can
+# be replaced.
+#
+# If the order ever changes we need to manually resolve this here and construct
+# the files here manually. For details how this can be done see:
+# https://github.com/snapcore/core/blob/master/live-build/hooks/00-uid-gid-fix.chroot_early
+#
+
+echo "Ensure passwd file does not change"
+diff -u <(cat /etc/passwd) <(cat <<EOF
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
+gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+systemd-network:x:101:102:systemd Network Management,,,:/run/systemd/netif:/usr/sbin/nologin
+systemd-resolve:x:102:103:systemd Resolver,,,:/run/systemd/resolve:/usr/sbin/nologin
+EOF
+)
+
+echo "Ensure group files does not change"
+diff -u <(cat /etc/group) <(cat <<EOF
+root:x:0:
+daemon:x:1:
+bin:x:2:
+sys:x:3:
+adm:x:4:
+tty:x:5:
+disk:x:6:
+lp:x:7:
+mail:x:8:
+news:x:9:
+uucp:x:10:
+man:x:12:
+proxy:x:13:
+kmem:x:15:
+dialout:x:20:
+fax:x:21:
+voice:x:22:
+cdrom:x:24:
+floppy:x:25:
+tape:x:26:
+sudo:x:27:
+audio:x:29:
+dip:x:30:
+www-data:x:33:
+backup:x:34:
+operator:x:37:
+list:x:38:
+irc:x:39:
+src:x:40:
+gnats:x:41:
+shadow:x:42:
+utmp:x:43:
+video:x:44:
+sasl:x:45:
+plugdev:x:46:
+staff:x:50:
+games:x:60:
+users:x:100:
+nogroup:x:65534:
+systemd-journal:x:101:
+systemd-network:x:102:
+systemd-resolve:x:103:
+EOF
+)


### PR DESCRIPTION
We *must* ensure that uid/gid never changes in the core image because
the UIDs will (potentially) leak out into the filesystem and /etc/passwd
and friends are part of the readonly part of the core snap so they can
be replaced.

As a drive-by this also removes the _apt user.