### PR TITLE
Fix core to work with systemd dynamic users (fixes systemd-timesyncd)

### DIFF
--- a/hooks/03-writable-paths.chroot
+++ b/hooks/03-writable-paths.chroot
@@ -43,10 +43,8 @@ cat > /etc/system-image/writable-paths << __WRITABLE__
 /etc/sudoers.d                          auto                    persistent  transition  none
 # systemd
 /etc/systemd                            auto                    persistent  transition  none
-/var/lib/systemd/random-seed            auto                    persistent  transition  none
-/var/lib/systemd/rfkill                 auto                    persistent  transition  none
-/var/lib/systemd/timesync               auto                    persistent  transition  none
-/var/lib/systemd/coredump               auto                    persistent  transition  none
+/var/lib/systemd                        auto                    persistent  transition  none
+/var/lib/private/systemd                auto                    persistent  transition  none
 # udev
 /etc/udev/rules.d                       auto                    persistent  transition  none
 /var/lib/extrausers                     auto                    persistent  transition  none

--- a/hooks/20-extra-files.chroot
+++ b/hooks/20-extra-files.chroot
@@ -21,5 +21,6 @@ mkdir -p /snap /var/snap
 mkdir -p /usr/lib/snapd
 
 echo "creating extra systemd dirs"
-mkdir -p /var/lib/systemd/timesync
 mkdir -p /var/lib/systemd/coredump
+mkdir -p /var/lib/private/systemd
+chmod 700 /var/lib/private


### PR DESCRIPTION
Starting with systemd 236-1, systemd-timesyncd switched from a static user to DynamicUser=yes for its service. This requires the /var/lib/private/systemd directory existing and /var/lib/systemd to be writable for dynamic creation of symlinks for dynamic users.