### PR TITLE
Clean up the leftover timesync directory on startup, if present

### DIFF
--- a/hooks/901-cleanup-timesyncd.chroot
+++ b/hooks/901-cleanup-timesyncd.chroot
@@ -9,8 +9,8 @@ set -e
 # XXX: This might not be needed in the end, but certainly useful now
 echo "Clean up systemd-timesyncd leftover directory"
 
-mkdir -p /lib/systemd/system/systemd-sysusers.service.d
-cat >/lib/systemd/system/systemd-sysusers.service.d/fixup-timesyncd.conf<<EOF
+mkdir -p /lib/systemd/system/systemd-tmpfiles-setup.service.d
+cat >/lib/systemd/system/systemd-tmpfiles-setup.service.d/fixup-timesyncd.conf<<EOF
 [Service]
 ExecStartPost=/bin/sh -c "[ ! -L /var/lib/systemd/timesync ] && rm -rf /var/lib/systemd/timesync | true"
 EOF

--- a/hooks/901-cleanup-timesyncd.chroot
+++ b/hooks/901-cleanup-timesyncd.chroot
@@ -12,6 +12,6 @@ echo "Clean up systemd-timesyncd leftover directory"
 mkdir -p /lib/systemd/system/systemd-tmpfiles-setup.service.d
 cat >/lib/systemd/system/systemd-tmpfiles-setup.service.d/fixup-timesyncd.conf<<EOF
 [Service]
-ExecStartPost=/bin/sh -c "[ ! -L /var/lib/systemd/timesync ] && rm -rf /var/lib/systemd/timesync | true"
+ExecStartPost=/bin/sh -c "[ ! -L /var/lib/systemd/timesync ] && rm -rf /var/lib/systemd/timesync || true"
 EOF
 

--- a/hooks/901-cleanup-timesyncd.chroot
+++ b/hooks/901-cleanup-timesyncd.chroot
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+# With newer systemd, systemd-timesyncd switched from a regular user usage to
+# dynamic users.  In cases of upgrades from an older core18 system or in some
+# other weird situations the old timesync directory needs removal as otherwise
+# systemd will fail creating dynamic user symlink and fail to start timesyncd.
+# XXX: This might not be needed in the end, but certainly useful now
+echo "Clean up systemd-timesyncd leftover directory"
+
+mkdir -p /lib/systemd/system/systemd-sysusers.service.d
+cat >/lib/systemd/system/systemd-sysusers.service.d/fixup-timesyncd.conf<<EOF
+[Service]
+ExecStartPost=/bin/sh -c "[ ! -L /var/lib/systemd/timesync ] && rm -rf /var/lib/systemd/timesync | true"
+EOF
+


### PR DESCRIPTION
 This is needed to make sure systemd-timesyncd will be able to start with dynamic users. Currently /lib/systemd/system is writable so we need to do that on boot - useful for cases of upgrading from older core18 systems. Might not be necessary in the end, but good to have it now.