### PR TITLE
hooks: add ca-certificates

### DIFF
--- a/hooks/00-extra-packages.chroot
+++ b/hooks/00-extra-packages.chroot
@@ -24,7 +24,8 @@ apt install --no-install-recommends -y \
     sudo \
     dbus \
     apparmor \
-    netplan.io
+    netplan.io \
+    ca-certificates
 
 
 # XXX: add console-conf (add 2Mb, can we get is as a snap?)


### PR DESCRIPTION
We need ca-certificates for ssl support in e.g. snapd.