### PR TITLE
hooks: ensure we have the right bootloader config

### DIFF
--- a/hooks/16-ensure-bootloaders.chroot
+++ b/hooks/16-ensure-bootloaders.chroot
@@ -1,0 +1,23 @@
+#!/bin/sh -ex
+
+echo "Create the boot mount points"
+mkdir -p /boot/androidboot
+mkdir -p /boot/uboot
+mkdir -p /boot/grub
+
+echo "Add uboot config on arm"
+case "$(dpkg --print-architecture)" in
+    armhf|arm64)
+        cat > /etc/fw_env.config <<EOF
+# snappy u-boot env config
+# its crucial that we have the two entries here
+#   u-boot/tools/env/fw_env.c 
+# will read only 4 header bytes if its a single
+# line but our header has 5 byte. by having two
+# entries like this in the config it magically
+# switches to the 5 byte header type
+/boot/uboot/uboot.env 0x0000 0x20000
+/boot/uboot/uboot.env 0x0000 0x20000
+EOF
+        ;;
+esac


### PR DESCRIPTION
This will ensure we have the right bootloader mount points.