### PR TITLE
Fix travis CI, switch it to xenial, enable non-bionic builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 os: linux
-dist: trusty
+dist: xenial
 sudo: enabled
 script:
   - sudo apt-get update

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -67,6 +67,7 @@ rm -rf /var/log/journal
 rm /var/log/*
 
 # no "local" on core18
+# shellcheck disable=SC2114
 rm -rf -- /var/local /usr/local
 
 # no debconf

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,3 +13,16 @@ parts:
     build-packages:
       - shellcheck
       - wget
+    # XXX: Dirty hacks to enable building core18 on non-bionic systems.
+    # Without these overrides both the PATH and LD_LIBRARY_PATH contain paths
+    # in the part's install directory which binaries can be incompatible with
+    # the ones running on our system.  We don't need those while running stage
+    # and prime anyway.
+    override-stage: |
+      unset LD_LIBRARY_PATH;
+      export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin";
+      snapcraftctl stage
+    override-prime: |
+      unset LD_LIBRARY_PATH;
+      export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin";
+      snapcraftctl prime


### PR DESCRIPTION
First, this change switches the travis CI env from trusty to xenial + silences a small shellcheck warning. Most importantly though we also modify the stage and prime steps to no longer make them segfault on non-bionic systems.
There seems to be an incompatibility in glibc between what we have in the bootstrapped part and the host system. Since snapcraft by default includes the part's install directories in both LD_LIBRARY_PATH and PATH, this causes chaos and results in everything segfaulting. As a workaround we override the stage and prime steps to not use the part's paths at all as we don't actually need them. 