### PR TITLE
Switch back to dist: trusty as xenial is not stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 os: linux
-dist: xenial
+dist: trusty
 sudo: enabled
 script:
   - sudo apt-get update


### PR DESCRIPTION
Even though officially supported, dist: xenial suffers from instabilities on travis CI, requiring frequent re-runs when dpkg lock problems appear.