### PR TITLE
static: add new core18.start-snapd.service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install:
 		rm -f $(DESTDIR)/tmp/$$(basename $$f); \
 	done;
 	# copy static files verbatim
-	cp -a static/* $(DESTDIR)
+	/bin/cp -a static/* $(DESTDIR)
 
 	# only generate manifest file for lp build
 	if [ -e /build/core18 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ install:
                 fi && \
 		rm -f $(DESTDIR)/tmp/$$(basename $$f); \
 	done;
+	# copy static files verbatim
+	cp -a static/* $(DESTDIR)
+
 	# only generate manifest file for lp build
 	if [ -e /build/core18 ]; then \
 		echo $$f; \

--- a/static/lib/systemd/system/core18.start-snapd.service
+++ b/static/lib/systemd/system/core18.start-snapd.service
@@ -2,7 +2,7 @@
 Description=Manage the snapd services from the snapd snap
 
 [Service]
-ExecStart=/usr/lib/core18/manage start
+ExecStart=/usr/lib/core18/run-snapd-from-snap start
 Type=oneshoot
 RemainAfterExit=true
 

--- a/static/lib/systemd/system/core18.start-snapd.service
+++ b/static/lib/systemd/system/core18.start-snapd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Manage the snapd services from the snapd snap
+
+[Service]
+ExecStart=/usr/lib/core18/manage start
+Type=oneshoot
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/static/lib/systemd/system/multi-user.target.wants/core18.start-snapd.service
+++ b/static/lib/systemd/system/multi-user.target.wants/core18.start-snapd.service
@@ -1,0 +1,1 @@
+../core18.start-snapd.service

--- a/static/usr/lib/core18/manage
+++ b/static/usr/lib/core18/manage
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# This script will try to find a suiteable snapd snap and start
+# snapd and its associated services from it.
+
+set -eux
+
+# try_start_snapd will try to start snapd from the given prefix
+# location
+try_start_snapd() {
+    PREFIX="$1"
+
+    if ! "$PREFIX"/usr/lib/snapd/snapd.manage start; then
+        echo "cannot start snapd from $PREFIX"
+        exit 1
+    fi
+    echo "$PREFIX" > /var/lib/snapd/last-good-snapd
+}
+
+# run_on_unseeded will mount/run snapd on an unseeded system
+run_on_unseeded() {
+    SEED_SNAPD="/var/lib/snapd/seed/snaps/snapd_*.snap"
+    if [ ! -e "$SEED_SNAPD" ]; then
+        echo "Cannot find a seeded snapd"
+        ls /var/lib/snapd/seed/snaps
+        exit 1
+    fi
+
+    # mount snapd snap and run snapd directly, it will do
+    # the seeding and as part of this will restart snapd
+    # which will give it the right systemd unit.
+    TMPD=$(mktemp -d)
+    trap "umount $TMPD; rmdir $TMPD" EXIT
+    mount "$SEED_SNAPD" "$TMPD"
+    "$TMPD"/lib/snapd/snapd
+}
+
+# Unseeded systems need to be seeded first, this will start snapd
+# and snapd will restart itself after the seeding.
+if [ ! -e /var/lib/snapd/state.json ]; then
+    if ! run_on_unseeded; then
+        echo "cannot run snapd from the seed"
+        exit 1
+    fi
+    exit 0
+fi
+
+# Try to run from the current and mounted snapd.
+if ! try_start_snapd "$(readlink -f /snap/snapd/current)"; then
+    if ! try_start_snapd "$(cat /var/lib/snapd/last-good-snapd)"; then
+        # FIXME: try harder here, eventually fallback to the seed
+        exit 1
+    fi
+fi
+

--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -10,7 +10,7 @@ set -eux
 try_start_snapd() {
     PREFIX="$1"
 
-    if ! "$PREFIX"/usr/lib/snapd/snapd.manage start; then
+    if ! "$PREFIX"/usr/lib/snapd/snapd.run-from-snap start "$PREFIX"; then
         echo "cannot start snapd from $PREFIX"
         exit 1
     fi


### PR DESCRIPTION
The new core18.start-snapd.service manages the snapd from the snapd
snap. It will run the seeding (if neeeded) and otherwise try to
start the right snapd from the snapd snap.

This is the initial version that will be able to run the seeding
and an installed snapd. It also contains basic fallback logic
where it will try to start the previous snapd if the current one
fails to run.

