### PR TITLE
static: add default netplan config

### DIFF
--- a/static/etc/netplan/00-snapd-config.yaml
+++ b/static/etc/netplan/00-snapd-config.yaml
@@ -1,0 +1,13 @@
+# This is the initial network config.
+# It can be overwritten by cloud-init or console-conf.
+network:
+    version: 2
+    ethernets:
+        all-en:
+            match:
+                name: "en*"
+            dhcp4: true
+        all-eth:
+            match:
+                name: "eth*"
+            dhcp4: true


### PR DESCRIPTION
Trivial PR to enable wired networking by default (just like we do on the "old" core 16).