### PR TITLE
run-snapd-from-snap: fix quoting for firstboot

### DIFF
--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -19,7 +19,7 @@ try_start_snapd() {
 
 # run_on_unseeded will mount/run snapd on an unseeded system
 run_on_unseeded() {
-    SEED_SNAPD="/var/lib/snapd/seed/snaps/snapd_*.snap"
+    SEED_SNAPD="$(find /var/lib/snapd/seed/snaps/ -name "snapd_*.snap")"
     if [ ! -e "$SEED_SNAPD" ]; then
         echo "Cannot find a seeded snapd"
         ls /var/lib/snapd/seed/snaps


### PR DESCRIPTION
The shell quoting is too strict so the current script will not find the seeded snapd.