### PR TITLE
hooks: add symlink from /usr/bin/snap -> /snap/snapd/current/usr/bin/snapd

### DIFF
--- a/hooks/050-snap-symlink.chroot
+++ b/hooks/050-snap-symlink.chroot
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+
+echo "Creating the snap binary symlink"
+ln -s /snap/snapd/current/usr/bin/snap /usr/bin/snap


### PR DESCRIPTION
We need something real in /usr/bin/snap because /snap/bin/* uses symlinks to that file.