### PR TITLE
Clean up some commented-out leftovers.

### DIFF
--- a/hooks/000-extra-packages.chroot
+++ b/hooks/000-extra-packages.chroot
@@ -29,6 +29,3 @@ apt install --no-install-recommends -y \
     squashfs-tools \
     console-conf
 
-
-# XXX: add console-conf (add 2Mb, can we get is as a snap?)
-#apt install --no-install-recommends -y console-conf


### PR DESCRIPTION
So, just a no-change cleanup.

But using the occasion... after latest mvo's changes and installing the snapd snap, console-conf fully works on core18! I filled in this subiquity PR to fix the version string though:

https://github.com/CanonicalLtd/subiquity/pull/360