### PR TITLE
run-snapd-from-snap: start snapd after seeding

### DIFF
--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -14,7 +14,7 @@ try_start_snapd() {
         echo "cannot start snapd from $PREFIX"
         exit 1
     fi
-    echo "$PREFIX" > /var/lib/snapd/last-good-snapd
+    echo "$(readlink -f $PREFIX)" > /var/lib/snapd/last-good-snapd
 }
 
 # run_on_unseeded will mount/run snapd on an unseeded system
@@ -32,7 +32,13 @@ run_on_unseeded() {
     TMPD=$(mktemp -d)
     trap "umount $TMPD; rmdir $TMPD" EXIT
     mount "$SEED_SNAPD" "$TMPD"
+    # snapd will restart once it seeded the snapd snap
     "$TMPD"/usr/lib/snapd/snapd
+    umount "TMPD" || true
+
+    # now start snapd normally, there is just a single snapd installed
+    # at this point
+    try_start_snapd "/snap/snapd/current"
 }
 
 # Unseeded systems need to be seeded first, this will start snapd
@@ -46,7 +52,11 @@ if [ ! -e /var/lib/snapd/state.json ]; then
 fi
 
 # Try to run from the current and mounted snapd.
-if ! try_start_snapd "$(readlink -f /snap/snapd/current)"; then
+if ! try_start_snapd "/snap/snapd/current"; then
+
+    # FIXME: at this point all our system units will be set to
+    #        /snap/snapd/$rev/ - which means when snapd restarts
+    #        it will not restart into the new version :/
     if ! try_start_snapd "$(cat /var/lib/snapd/last-good-snapd)"; then
         # FIXME: try harder here, eventually fallback to the seed
         exit 1


### PR DESCRIPTION
When snapd is seeding and it finised seeding the snapd snap it
will restart itself. The run-snapd-from-snap script can just
start snapd normally at this point. By just using the "current"
symlink we also ensure that each new snapd will restart into
the current version. The downside of this is that it makes
rollback handling of snapd harder.

This requires https://github.com/snapcore/snapd/pull/5330 to
work but it does no harm even if #5330 is not merged.