### PR TITLE
hooks: add cloud-init

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -27,5 +27,6 @@ apt install --no-install-recommends -y \
     netplan.io \
     ca-certificates \
     squashfs-tools \
-    console-conf
+    console-conf \
+    cloud-init
 

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -18,7 +18,10 @@ rm -rvf /etc/binfmt.d
 rm /etc/gai.conf
 rm /etc/debian_version
 rm /etc/pam.conf
-rmdir /etc/profile.d
+
+# cloud-init adds stuff here
+rm -rf /etc/profile.d
+
 rm /etc/rmt
 rm /etc/sysctl.conf
 rm -rf /etc/terminfo


### PR DESCRIPTION
This may help with the current failure of running core18 inside google-compute-engine.