### PR TITLE
writable-paths: add needed paths for cloud-init

### DIFF
--- a/static/etc/cloud/cloud.cfg.d/10_snappy.cfg
+++ b/static/etc/cloud/cloud.cfg.d/10_snappy.cfg
@@ -1,0 +1,28 @@
+#cloud-config
+
+# growpart module fails as 'sgdisk' is not present
+# but even if it were, we would not want to run it
+growpart:
+   mode: off
+
+# resize_rootfs (using resize2fs) fails, we wouldnt want resize
+# of the root partition anyway (data partition would be more useful).
+resize_rootfs: False
+
+# lock_passwd writes warning due to failure of 'usermod --lock'
+# use netplan for rendering network config
+system_info:
+   default_user:
+     lock_passwd: True
+   network:
+       renderers: ['netplan']
+
+# disable running 'locale-gen' as it does not run successfully
+locale: False
+
+# disable re-configuring grub for dynamic boot devices
+grub_dpkg:
+   enabled: False
+
+# apt_pipelining logs warning on failed write to /etc/apt/apt.conf.d
+apt_pipelining: "none"

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -1,9 +1,3 @@
-#!/bin/sh
-set -e
-# XXX: we want to migrate away from writable paths but having _some_ support of
-# this for now lets us walk before we run.
-mkdir -p /etc/system-image
-cat > /etc/system-image/writable-paths << __WRITABLE__
 # --------------------------------------------------------------------
 # 1st column: Mount point
 # 2nd column: Path relative to root of persistent storage (or auto)
@@ -57,4 +51,3 @@ cat > /etc/system-image/writable-paths << __WRITABLE__
 /var/lib/apparmor                       auto                    persistent  transition  none
 /var/lib/dbus                           auto                    persistent  none        none
 /var/lib/dhcp                           auto                    persistent  none        none
-__WRITABLE__

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -51,3 +51,8 @@
 /var/lib/apparmor                       auto                    persistent  transition  none
 /var/lib/dbus                           auto                    persistent  none        none
 /var/lib/dhcp                           auto                    persistent  none        none
+# cloud-init
+/etc/cloud                              auto                    synced  none        none
+/var/lib/cloud                          auto                    persistent  none        none
+# for various clouds like GCE
+/etc/sysctl.d                           auto                    persistent  transition  none


### PR DESCRIPTION
This ports writeable bits from core16 to (hopefully) make cloud-init work on core18.

Based on #31 