### PR TITLE
hooks: install net-tools package

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -25,6 +25,7 @@ apt install --no-install-recommends -y \
     dbus \
     apparmor \
     netplan.io \
+    net-tools \
     ca-certificates \
     squashfs-tools \
     console-conf \


### PR DESCRIPTION
This will add ifconfig/netstat to core18 which is useful in the
tests and more convinient for admins than using "ip".