### PR TITLE
hooks: make /usr/bin/snapctl available in the base

### DIFF
--- a/hooks/020-extra-files.chroot
+++ b/hooks/020-extra-files.chroot
@@ -30,3 +30,6 @@ chmod 700 /var/lib/private
 echo "extra cloud init files"
 mkdir -p /etc/cloud
 mkdir -p /var/lib/cloud
+
+echo "ensure snapctl is available"
+ln -s ../lib/snapd/snapctl /usr/bin/snapctl


### PR DESCRIPTION
Combined with https://github.com/snapcore/snapd/pull/5375 this will
allow snaps that use core18 to use the snapctl helper. Right now
this helper is not available inside the snap because only
/usr/lib/snapd is mounted inside the snap but not /usr/bin/snapctl.