### PR TITLE
hooks: set timezone to Etc/UTC

### DIFF
--- a/hooks/030-fix-timedatectl.chroot
+++ b/hooks/030-fix-timedatectl.chroot
@@ -31,3 +31,6 @@ esac
 EOF
 
 chmod 755 /usr/bin/timedatectl
+
+echo "Ensure /etc/timezone is valid"
+echo "Etc/UTC" > /etc/timezone


### PR DESCRIPTION
For some reason the timezone on core18 is currently set to "/UTC" which is invalid. This sets it to something valid. This should fix the `interfaces-timezone-control` test on core18.