### PR TITLE
hooks: add libpam-systemd

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -16,6 +16,7 @@ apt install --no-install-recommends -y \
     systemd \
     systemd-sysv \
     libnss-extrausers \
+    libpam-systemd \
     distro-info-data \
     tzdata \
     openssh-server \


### PR DESCRIPTION
We do not currently install libpam-systemd and I suspect this is why the PATH for regular users is not set correctly. This is an experiment to see if this fixes the missing /snap/bin in PATH.