### PR TITLE
hooks: ensure /etc/login.defs PATHs contain /snap/bin

### DIFF
--- a/hooks/022-setup-path.chroot
+++ b/hooks/022-setup-path.chroot
@@ -6,3 +6,7 @@
 echo "putting a PATH in place that contains /snap/bin"
 echo 'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"' >/etc/environment
 
+
+echo "Ensure /etc/login.defs contains /snap/bin"
+sed -i 's#\(.*\)PATH=\(.*\)#\1 PATH=\2:/snap/bin#' /etc/login.defs
+grep 'PATH=.*:/snap/bin' /etc/login.defs


### PR DESCRIPTION
In ubuntu 18.04 /etc/environment is no longer used for the PATH
when using "su". It is unclear if this is a desired change but
until the root cause is found this PR adds /snap/bin to the PATH
in /etc/login.defs which is read by "su".

This will also unbreak some snapd integration tests that use
'su -l -c "cmd" test'.