### PR TITLE
hooks: add FIXME for /etc/login.defs changes

### DIFF
--- a/hooks/022-setup-path.chroot
+++ b/hooks/022-setup-path.chroot
@@ -6,7 +6,12 @@
 echo "putting a PATH in place that contains /snap/bin"
 echo 'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"' >/etc/environment
 
-
+# FIXME:
+# The "su.c" file from shadow is buggy and reads the pam environment first
+# and then overrides with the login.defs environment. This will be fixed
+# when https://github.com/shadow-maint/shadow/pull/119 is merged or when
+# we switch to "su" from util-linux. Until this is the case we need the
+# workaround below.
 echo "Ensure /etc/login.defs contains /snap/bin"
 sed -i 's#\(.*\)PATH=\(.*\)#\1 PATH=\2:/snap/bin#' /etc/login.defs
 grep 'PATH=.*:/snap/bin' /etc/login.defs


### PR DESCRIPTION
The "su.c" file from shadow is buggy and reads the pam environment first
and then overrides with the login.defs environment. This will be fixed
when https://github.com/shadow-maint/shadow/pull/119 is merged or when
we switch to "su" from util-linux. Until this is the case we need the
workaround in hooks/022-setup-path.chroot.