### PR TITLE
Revert "static: add systemd environment generator to ensure PATH contains /snap/bin"

### DIFF
--- a/static/usr/lib/systemd/systemd-environment-generators/50-snapd.sh
+++ b/static/usr/lib/systemd/systemd-environment-generators/50-snapd.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-#
-# Ensure /snap/bin is in the PATH
-
-echo PATH=$PATH:/snap/bin


### PR DESCRIPTION
This reverts commit a9c4ea6ff0732911a47fa7a1b035eb10c1e68cd4.

After some research it turns out that the problem with "PATH" in
su -l is a bug there (see https://github.com/shadow-maint/shadow/pull/119).

We don't need the generator having the right PATH in /etc/environment is
enough for non-broken tools.