### PR TITLE
hooks: fix 030-fix-timedatectl.chroot to DTRT when running on non-core devices

### DIFF
--- a/hooks/030-fix-timedatectl.chroot
+++ b/hooks/030-fix-timedatectl.chroot
@@ -19,10 +19,14 @@ TIMEDATECTL=/usr/bin/timedatectl.real
 case $1 in
     set-timezone)
         $TIMEDATECTL set-timezone $2
-        # make a .tmp link and mv it to have "kind of" atomic
-        # writing here in case of a power loss midway through
-        ln -s /usr/share/zoneinfo/$2 /etc/writable/localtime.tmp
-        mv /etc/writable/localtime.tmp /etc/writable/localtime
+        # do special handling on core devices (there /etc/localtime
+        # is a symlink to /etc/writable/localtime)
+        if [ -L /etc/writable/localtime ]; then
+            # make a .tmp link and mv it to have "kind of" atomic
+            # writing here in case of a power loss midway through
+            ln -s /usr/share/zoneinfo/$2 /etc/writable/localtime.tmp
+            mv /etc/writable/localtime.tmp /etc/writable/localtime
+        fi
         ;;
     *)
         $TIMEDATECTL $@


### PR DESCRIPTION
See also https://github.com/snapcore/core/pull/89 - we should probably only land this once the other PR is landed and tests are green.