### PR TITLE
hooks: make hostname empty but the file needs to exist

### DIFF
--- a/hooks/019-unset-hostname.chroot
+++ b/hooks/019-unset-hostname.chroot
@@ -1,3 +1,3 @@
 #!/bin/sh -ex
 
-rm -f /etc/hostname
+echo "" > /etc/hostname

--- a/tests/main/hostname/task.yaml
+++ b/tests/main/hostname/task.yaml
@@ -1,4 +1,4 @@
 summary: Ensure that there is no hostname set
 execute: |
-    test ! -e /etc/hostname
+    test -e /etc/hostname
     test "$(hostname)" = localhost


### PR DESCRIPTION
This fixes the cloud-init service failing.