### PR TITLE
hooks: preserve /usr/local/share/fonts

### DIFF
--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -72,6 +72,9 @@ rm /var/log/*
 # no "local" on core18
 # shellcheck disable=SC2114
 rm -rf -- /var/local /usr/local
+# we need this for the core18 base snap when using with classic snaps
+# for the "interfaces-desktop-host-fonts"
+mkdir -p /usr/local/share/fonts
 
 # no debconf
 rm -rf /var/cache/debconf


### PR DESCRIPTION
This is used by the interfaces-desktop-host-fonts interface when core18 is used as a base snap for e.g. gnome applications on classic.