### PR TITLE
hooks: ensure fix for entropy hang at boot is part of the image

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -33,3 +33,10 @@ apt install --no-install-recommends -y \
     console-conf \
     cloud-init
 
+
+# Install libuuid1 fix, see https://launchpad.net/bugs/1783810
+# This can be removed once LP#1783810 is fixed.
+echo "deb http://archive.ubuntu.com/ubuntu bionic-proposed main" > /etc/apt/sources.list.d/lp1783810.list
+apt update
+apt install --only-upgrade libuuid1
+rm  /etc/apt/sources.list.d/lp1783810.list


### PR DESCRIPTION
Right now the boot of core18 with kernel 4.15 may hang because
the kernel has not enough entropy in early boot yet but libuuid
is using getrandom() for the uuid generation. When parted is
used in early boot to resize the disk this lead to a hang.