### PR TITLE
Tell agetty from console-conf not to print /etc/issue as console-conf does it for us.

### DIFF
--- a/hooks/101-do-not-print-issue.chroot
+++ b/hooks/101-do-not-print-issue.chroot
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# In core16 we did not actually print /etc/issue on the terminal as
+# console-conf does that for us.  Probably something changed in agetty?
+# We can hack around it by explicitly forwarding -i to the agetty command.
+
+sed -i 's/\/sbin\/agetty /\/sbin\/agetty -i /' /lib/systemd/system/console-conf@.service

--- a/hooks/101-do-not-print-issue.chroot
+++ b/hooks/101-do-not-print-issue.chroot
@@ -4,4 +4,4 @@
 # console-conf does that for us.  Probably something changed in agetty?
 # We can hack around it by explicitly forwarding -i to the agetty command.
 
-sed -i 's/\/sbin\/agetty /\/sbin\/agetty -i /' /lib/systemd/system/console-conf@.service
+sed -i 's/\/sbin\/agetty /\/sbin\/agetty -i /' /lib/systemd/system/console-conf@.service /lib/systemd/system/serial-console-conf\@.service


### PR DESCRIPTION
In core16 agetty (for some reason?) did not print /etc/issue on terminals. Now it does and we need to explicitly tell it not to do so. We're using console-conf to print all the info for us, so we actually really don't want agetty to do anything here. Without this, after setting up the system we get duplicated info for what system is running here.

This should essentially be fixed in subiquity as well. This workaround can then be removed.