### PR TITLE
 static: cleanup writable-path and remove all synced dirs 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ install:
 	tar -x -f ../$(BASE) -C $(DESTDIR)
 	# ensure resolving works inside the chroot
 	cat /etc/resolv.conf > $(DESTDIR)/etc/resolv.conf
+	# copy static files verbatim
+	/bin/cp -a static/* $(DESTDIR)
 	# customize
 	set -ex; for f in ./hooks/[0-9]*.chroot; do \
 		/bin/cp -a $$f $(DESTDIR)/tmp && \
@@ -28,8 +30,6 @@ install:
                 fi && \
 		rm -f $(DESTDIR)/tmp/$$(basename $$f); \
 	done;
-	# copy static files verbatim
-	/bin/cp -a static/* $(DESTDIR)
 
 	# only generate manifest file for lp build
 	if [ -e /build/core18 ]; then \

--- a/hooks/991-no-synced-dirs.chroot
+++ b/hooks/991-no-synced-dirs.chroot
@@ -1,0 +1,6 @@
+#!/bin/sh -ex
+
+if grep -v '^#' </etc/system-image/writable-paths | grep synced; then
+    echo "Using 'synced' in /etc/system-image/writable-paths is not allowed in core18"
+    exit 1
+fi

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -8,11 +8,11 @@
 # See writable-paths(5) for full details.
 # --------------------------------------------------------------------
 /home                                   user-data               persistent  transition  none
-/snap                                   auto                    persistent  none  none
+/snap                                   auto                    persistent  none        none
 # snappy security policy, etc
-/var/lib/snapd                         auto                     synced      none        none
+/var/lib/snapd                         auto                     persistent  transition  none
 # snap catalogue (sections, pkgnames)
-/var/cache/snapd                        auto                   synced      none        none
+/var/cache/snapd                        auto                    persistent  transition  none
 # snap data
 /var/snap                               auto                    persistent  transition  none
 # generic
@@ -22,14 +22,14 @@
 /tmp                                    none                    temporary   none        defaults
 /var/tmp                                auto                    persistent  transition  none
 # etc related
-/etc/writable                           auto                    synced      none        none
+/etc/writable                           auto                    persistent  none        none
 # apparmor
 /etc/apparmor.d/cache                   auto                    persistent  none        none
 # dbus system bus
 /etc/dbus-1/system.d                    auto                    persistent  transition  none
 /etc/hosts                              auto                    persistent  transition  none
 /etc/iproute2                           auto                    persistent  transition  none
-/etc/modprobe.d                         auto                    synced      none        none
+/etc/modprobe.d                         auto                    persistent  transition  none
 /etc/modules-load.d                     auto                    persistent  transition  none
 /etc/netplan                            auto                    persistent  transition  none
 /etc/network/if-up.d                    auto                    persistent  transition  none
@@ -52,7 +52,7 @@
 /var/lib/dbus                           auto                    persistent  none        none
 /var/lib/dhcp                           auto                    persistent  none        none
 # cloud-init
-/etc/cloud                              auto                    synced  none        none
+/etc/cloud                              auto                    persistent  transition  none
 /var/lib/cloud                          auto                    persistent  none        none
 # for various clouds like GCE
 /etc/sysctl.d                           auto                    persistent  transition  none


### PR DESCRIPTION
Also add test that ensures "synced" dirs are no longer used and run hooks after static content.

The "synced" filemode for the writable-paths had resulted in subtle
bugs in the past. One issue is that it is not possible to delete
a file in "synced" mode, because writable-paths will always
re-create the file from the core18 image. There are more subtle
issues so we should not rely on this.