### PR TITLE
[RFC] snapcraft.yaml: add current date to core18 rev

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,8 @@
 name: core18
-version: 0.1
+version: 18
+version-script: |
+  . prime/etc/os-release
+  echo "${VERSION_ID}+$(date +%Y%M%d)"
 summary: Runtime environment based on Ubuntu 18.04
 description: |
   The base snap based on the Ubuntu 18.04 release.


### PR DESCRIPTION
This is a bit of an RFC/brainstorm PR - the current core18 version is 0.1 which is a bit silly. So this is about finding a better one. One option (the one in this PR) is to use "18-$current_date" - but other ideas are welcome of course too, I think we want to convey an idea of "freshness" so just using "version: 18" might not be ideal. Otoh the revno is increasing so maybe it is enough.