### PR TITLE
hooks: improve /etc/alternatives unwinding

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -2,6 +2,8 @@
 
 set -eux
 
+export DEBIAN_FRONTEND=noninteractive
+
 # ensure we have /proc or systemd will fail
 mount -t proc proc /proc
 trap 'umount /proc' EXIT

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -50,19 +50,6 @@ rm -rf /usr/local/lib/python*
 # we have no cron daily jobs
 rmdir /etc/cron.daily
 
-# undo all symlinks to /etc/alternatives and replace with their real
-# counterparts. The alternatives system looks like this:
-#
-# /usr/bin/pager -> /etc/alternatives/pager -> /bin/more
-#
-find /etc/alternatives -type l | while read -r f; do
-    real=$(readlink -f "$f")
-    alias=$(dirname "$real")/$(basename "$f")
-    rm -f "$alias"
-    ln -s "$real" "$alias"
-done
-rm -rf /etc/alternatives
-
 # no permanet journal
 rm -rf /var/log/journal
 

--- a/hooks/910-unwind-alternatives.chroot
+++ b/hooks/910-unwind-alternatives.chroot
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+# undo all symlinks to /etc/alternatives and replace with their real
+# counterparts. The alternatives system looks like this:
+#
+# /usr/bin/pager -> /etc/alternatives/pager -> /bin/more
+#
+# Do this by:
+# 1. find symlinks "f" into /etc/alternatives/
+#    e.g. /usr/bin/pager -> /etc/alternatives/pager
+# 2. get the symlink "target" of the links
+#    e.g. /etc/alternatives/pager -> /bin/less
+# 3. link original symlink "f" directly to target of alternatives,
+#    e.g. /usr/bin/pager -> /bin/less
+find / -xdev -type l | while read -r f; do
+    target=$(readlink "$f")
+    if [[ "$target" == /etc/alternatives/* ]]; then
+        real=$(readlink "$target")
+        echo "unwinding alternatives $real -> $f"
+        rm -f "$f"
+        ln -s "$real" "$f"
+    fi
+done
+# and do the final cleanup
+rm -rf /etc/alternatives
+


### PR DESCRIPTION
The previous approach of unwinding alternatives had the problem
that e.g. /usr/bin/pager -> /etc/alternatives/pager -> /bin/more
would end up with a "/bin/pager".

This PR fixes this bug. It also splits the alternatives finding
into its own hook script.

One unrelated fix (DEBIAN_FRONTEND).