### PR TITLE
snapcraft.yaml: switch version from 0.1 to 18

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: core18
-version: 0.1
+version: 18
 summary: Runtime environment based on Ubuntu 18.04
 description: |
   The base snap based on the Ubuntu 18.04 release.


### PR DESCRIPTION
The version 0.1 does no longer reflect reality. Therefore switch
to version 18 for now. We will need to find a better version
numbering schema. However until this is finalized we can simply
go with 18.