### PR TITLE
Install rsyslog in core18.

### DIFF
--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -163,7 +163,7 @@ root:x:0:
 daemon:x:1:
 bin:x:2:
 sys:x:3:
-adm:x:4:
+adm:x:4:syslog
 tty:x:5:
 disk:x:6:
 lp:x:7:
@@ -222,7 +222,7 @@ root:*::
 daemon:*::
 bin:*::
 sys:*::
-adm:*::
+adm:*::syslog
 tty:*::
 disk:*::
 lp:*::

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -43,7 +43,8 @@ apt install --no-install-recommends -y \
     netplan.io \
     ca-certificates \
     squashfs-tools \
-    console-conf
+    console-conf \
+    rsyslog
 
 # since we installed what we wanted, let's get rid of the extra gnupg and all
 # its dependencies


### PR DESCRIPTION
Experimental. Having rsyslog is very helpful during debugging - right now there's not much logs we can get from a core18 image that's misbehaving. Couldn't test this on a fresh image yet (because https://github.com/snapcore/snapd/pull/5772 is needed for that).