### PR TITLE
hooks: add libpam-modules

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -28,6 +28,7 @@ apt install --no-install-recommends -y \
     systemd-sysv \
     libnss-extrausers \
     libpam-systemd \
+    libpam-modules \
     distro-info-data \
     tzdata \
     openssh-server \


### PR DESCRIPTION
The libpam-modules package ships the pam_permit.so module which
is needed by /etc/pam.d/common-passwd when using extrausers.

This fixes the bug that chpasswd is not working on a UC18 system
right now for users in the extrausers database.