### PR TITLE
hooks: use relative symlinks when unwinding

### DIFF
--- a/hooks/910-unwind-alternatives.chroot
+++ b/hooks/910-unwind-alternatives.chroot
@@ -13,14 +13,14 @@ set -e
 # 2. get the symlink "target" of the links
 #    e.g. /etc/alternatives/pager -> /bin/less
 # 3. link original symlink "f" directly to target of alternatives,
-#    e.g. /usr/bin/pager -> /bin/less
+#    and use a relative link, e.g. /usr/bin/pager -> ../bin/less
 find / -xdev -type l | while read -r f; do
     target=$(readlink "$f")
     if [[ "$target" == /etc/alternatives/* ]]; then
         real=$(readlink "$target")
         echo "unwinding alternatives $real -> $f"
         rm -f "$f"
-        ln -s "$real" "$f"
+        ln -s "$(realpath --relative-to="$(dirname "$f")" "$real")" "$f"
     fi
 done
 # and do the final cleanup


### PR DESCRIPTION
This is the core18 version of:
https://github.com/snapcore/core/pull/96

"""
The /etc/alternatives unwinding is currently creating absolute
paths. This can cause problems for classic snaps. The issue is
that on a classic snap /snap/core/current/usr/bin/awk will point
to /usr/bin/gawk - however this awk version may not be installed
on the host machine. Ironically this worked before because the
/snap/core/current/usr/bin/awk points to /etc/alternatives of
the host which may point to e.g. mawk (but potentially everyone
using the snap would see a different awk version).

This PR fixes this by using relative symlinks when unwinding the
alternatives. So it will /usr/bin/awk -> ./gawk
"""