### PR TITLE
writable-path: enable persistent journal

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -45,7 +45,7 @@
 /var/lib/misc                           auto                    persistent  transition  none
 /var/lib/sudo                           auto                    temporary   none        defaults,mode=0700
 /var/log                                auto                    persistent  transition  none
-
+/var/log/journal                        auto                    persistent  transition  none
 /var/lib/console-conf                   auto                    persistent  transition  none
 /var/cache/apparmor                     auto                    persistent  transition  none
 /var/lib/apparmor                       auto                    persistent  transition  none


### PR DESCRIPTION
We currently do not have a persistent log on UC18. However this
can be problematic so this PR adds /var/log/journal to the writable
dirs which will enable the persistent journal feature of journald.

One open question is if we should enable it by default for everyone
or make this a core config option to enable/disable as desired.