### PR TITLE
hooks: run console-conf after snapd.seeded.service

### DIFF
--- a/hooks/200-console-conf-after.chroot
+++ b/hooks/200-console-conf-after.chroot
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+# Ensure that snapd.seeded is complete so that the "snap" command is available
+# and useful.
+echo "Fix console-conf systemd unit to run after snapd.seeded.service"
+sed -i 's/After=rc-local.service/After=rc-local.service snapd.seeded.service/' /lib/systemd/system/console-conf@.service


### PR DESCRIPTION
Ensure that snapd.seeded is complete so that the "snap" command
is available and usable when the console-conf-wrapper is run.

This should fix the "snap not found" error on slow(ish) systems
like the pi2 on firstboot.