### PR TITLE
static: show snapd firstboot messages on /dev/console 

### DIFF
--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -22,7 +22,7 @@ run_on_unseeded() {
     mount "$SEED_SNAPD" "$TMPD"
     # snapd will write all the needed snapd.{service,socket}
     # units and restart once it seeded the snapd snap
-    "$TMPD"/usr/lib/snapd/snapd
+    "$TMPD"/usr/lib/snapd/snapd 2>&1 | tee -a /dev/console
 
     # ensure the snapd.socket gets restarted after seeding, the
     # snapd binary in seeding runs without systemd sockets and


### PR DESCRIPTION
This makes seeing progress and/or failures easier.