### PR TITLE
static: make run-snapd-from-snap wait for seeding

### DIFF
--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -28,6 +28,11 @@ run_on_unseeded() {
     # snapd binary in seeding runs without systemd sockets and
     # will delete its the socket files it created on exit.
     systemctl restart snapd.socket || true
+
+    # At this point the snap command is available. We need to
+    # wait here until seeding is done. This will ensure that
+    # console-conf works correctly.
+    snap watch --last=seed | tee -a /dev/console
 }
 
 # Unseeded systems need to be seeded first, this will start snapd


### PR DESCRIPTION
We need to wait in core18.run-snapd.service for snapd to be fully
seeded. This is required because console-conf runs after
core18.run-snapd.service but we cannot make it run after
snapd.seeded.service because at the time when the dependencies
for core18.run-snapd.service are calculated by systemd there is
no snapd.seeded yet.

It also redirects the output of the seeding to the console so
that its easier to see what is going on during seeding.