### PR TITLE
static: show seed progress on console on firstboot

### DIFF
--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -22,24 +22,12 @@ run_on_unseeded() {
     mount "$SEED_SNAPD" "$TMPD"
     # snapd will write all the needed snapd.{service,socket}
     # units and restart once it seeded the snapd snap
-    "$TMPD"/usr/lib/snapd/snapd 2>&1 | tee -a /dev/console
+    "$TMPD"/usr/lib/snapd/snapd
 
     # ensure the snapd.socket gets restarted after seeding, the
     # snapd binary in seeding runs without systemd sockets and
     # will delete its the socket files it created on exit.
     systemctl restart snapd.socket || true
-
-    # At this point the snap command is available. We need to
-    # wait here until seeding is done. This will ensure that
-    # console-conf works correctly.
-    snap watch --last=seed | tee -a /dev/console
-
-    # debug
-    for _ in $(seq 5); do
-        snap changes | tee -a /dev/console
-        snap watch --last=seed | tee -a /dev/console
-        sleep 1
-    done
 }
 
 # Unseeded systems need to be seeded first, this will start snapd

--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -20,6 +20,12 @@ run_on_unseeded() {
     TMPD=$(mktemp -d)
     trap "umount $TMPD; rmdir $TMPD" EXIT
     mount "$SEED_SNAPD" "$TMPD"
+
+    # Show progress on the console while seeding. console-conf
+    # will only come up after this unit is finished so without
+    # this users will look at a blank screen for a long time.
+    (sleep 1 ; "$TMPD"/usr/bin/snap watch --last=seed 2>&1 | tee -a /dev/console )&
+
     # snapd will write all the needed snapd.{service,socket}
     # units and restart once it seeded the snapd snap
     "$TMPD"/usr/lib/snapd/snapd


### PR DESCRIPTION
On firstboot console-conf will only come up after the system is seeded. This means that for several second the system will look like its hanging without any progress indication. This is especially noticeable on slow hardware like the Pi. 

This PR makes the seeding progress visible on the console.