### PR TITLE
hooks: port classic mode generation to UC18

### DIFF
--- a/hooks/005-create-classic-diff.chroot
+++ b/hooks/005-create-classic-diff.chroot
@@ -1,0 +1,35 @@
+#! /bin/sh -ex
+#
+# create delta tarball for classic shell
+
+echo "I: Creating delta tarball for use with classic shell"
+
+# create a classic tarball
+mkdir -p var/lib/classic
+apt-get clean
+apt-get -y install --reinstall -d apt locales base-files libapt-inst2.0 libapt-pkg5.0 ubuntu-keyring lsb-release
+cp /var/cache/apt/archives/*.deb var/cache/apt/archives/
+
+tar czvf var/lib/classic/classic-diff.tgz \
+     usr/bin/dpkg* \
+     var/lib/dpkg \
+     etc/alternatives \
+     var/cache/apt/archives/*.deb
+
+cat << EOF > var/lib/classic/enable.sh
+#! /bin/sh
+
+set -e
+
+rm -f /usr/local/bin/* /etc/apt/sources.list.d/*
+
+tar xf /var/lib/classic/classic-diff.tgz -C /
+
+dpkg -i /var/cache/apt/archives/*.deb
+dpkg -i --force-confask --force-confnew /var/cache/apt/archives/base-files*.deb
+
+apt-get clean
+apt-get update
+EOF
+
+chmod +x var/lib/classic/enable.sh


### PR DESCRIPTION
A bit of a RFC at this point, please do *not* merge just yet. I want to see how much it increases the size of the core18 snap.

Looking at this it adds 6MB to the core18 snap. Given the limited number of people who use classic mode and the large number of people who use core18 as their base I'm not sure this is the right trade-off.  I will work on an alternative implementation.

See also https://forum.snapcraft.io/t/classic-dimension-for-core18/7985