### PR TITLE
Placeholder files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ test:
 	set -ex; for f in ./tests/abi/*.sh; do \
 		$$f; \
 	done;
+	# run final tests on the prime dir
+	set -ex; for f in ./tests/final/*.sh; do \
+		$$f; \
+	done;
 
 # Display a report of files that are (still) present in /etc
 .PHONY: etc-report

--- a/hooks/008-etc-writable.chroot
+++ b/hooks/008-etc-writable.chroot
@@ -8,9 +8,11 @@ for f in timezone localtime hostname; do
     if [ -e /etc/$f ]; then
         echo "I: Moving /etc/$f to /etc/writable/"
         mv /etc/$f /etc/writable/$f
+    else
+        touch /etc/writable/$f
     fi
     echo "I: Linking /etc/$f to /etc/writable/"
-    ln -s /etc/writable/$f /etc/$f
+    ln -s writable/$f /etc/$f
 done
 
 # create systemd override dirs

--- a/tests/final/etc-writeable-symlinks.sh
+++ b/tests/final/etc-writeable-symlinks.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+echo "Test that the symlinks for etc/{timezone,localtime,hostname} exist"
+for f in timezone localtime hostname; do
+    test -e prime/etc/$f;
+done


### PR DESCRIPTION
There is a bugreport in the forum that there are some broken
symlinks in /etc that should point to /etc/writable. This PR
create placeholder files and makes the symlinks relative.

(cc @vorlonofportland for awareness so that he can subscribe the right people of his team)