### PR TITLE
Make /etc/default/swapfile be writable

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -56,3 +56,5 @@
 /var/lib/cloud                          auto                    persistent  none        none
 # for various clouds like GCE
 /etc/sysctl.d                           auto                    persistent  transition  none
+# swapfile
+/etc/default/swapfile                   auto                    persistent  transition  none


### PR DESCRIPTION
The /etc/default/swapfile should be writable. Add /etc/default/swapfile into writable-paths.