### PR TITLE
run-snapd-from-core: fix race when restarting snapd.socket

### DIFF
--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -30,6 +30,11 @@ run_on_unseeded() {
     # will delete its the socket files it created on exit.
     systemctl restart snapd.socket || true
 
+    # also ensure snapd.seeded.service is restarted and does not
+    # look at the no-longer-available socket file that snapd that ran
+    # without systemd created and that is no longer usable
+    systemctl restart snapd.seeded.service || true
+
     # At this point snap is available and seeding is at the point where
     # were snapd to installed and restarted successfully. Show progress
     # now. Even without showing progress we *must* wait here until


### PR DESCRIPTION
In the early core18 bootstrap there is no systemd owned
snapd.socket. The snapd daemon starts and creates this
socket itself. However when snapd restarts itself golang
will remove this socket (we have no control over this).

This may mean that the snapd.seeded job has the wrong
socket open (the socket that was owned by the bootstraping
snapd) and because there is no snapd anymore behind this
socket the snapd.seeded service fails.

To fix this the snapd.seeded service is also restarted
after the snapd.socket gets restarts. This ensures that
the snapd.seeded service will watch the right socket.