### PR TITLE
hooks: add symlinks for snapd's D-Bus configuration files

### DIFF
--- a/hooks/051-dbus-config-symlinks.chroot
+++ b/hooks/051-dbus-config-symlinks.chroot
@@ -1,0 +1,7 @@
+#!/bin/sh -ex
+
+echo "Creating D-Bus configuration file symlinks"
+mkdir -p /usr/share/dbus-1/session.d
+ln -s /snap/snapd/current/usr/share/dbus-1/session.d/snap-session.conf /usr/share/dbus-1/session.d/snap-session.conf
+mkdir -p /usr/share/dbus-1/system.d
+ln -s /snap/snapd/current/usr/share/dbus-1/system.d/snap-system.conf /usr/share/dbus-1/system.d/snap-system.conf


### PR DESCRIPTION
This is a companion to https://github.com/snapcore/snapd/pull/6258

In that PR, snapd is modified to install D-Bus service activation files to `/var/lib/snapd/dbus/services` and `.../dbus/system-services`.  In order for dbus-daemon to see those service files, it installs configuration fragments pointing to the new service dirs.

Those configuration fragments are not currently present on a core18 system, so the tests fail.  This PR simply symlinks the configuration fragments from the snapd snap.