### PR TITLE
static: add snapd.seeded.service to core18

### DIFF
--- a/static/lib/systemd/system/snapd.seeded.service
+++ b/static/lib/systemd/system/snapd.seeded.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Wait until snapd is fully seeded (core18)
+After=core18.start-snapd snapd.service snapd.socket
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/snap wait system seed.loaded
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target cloud-final.service

--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -30,11 +30,6 @@ run_on_unseeded() {
     # will delete its the socket files it created on exit.
     systemctl restart snapd.socket || true
 
-    # also ensure snapd.seeded.service is restarted and does not
-    # look at the no-longer-available socket file that snapd that ran
-    # without systemd created and that is no longer usable
-    systemctl restart snapd.seeded.service || true
-
     # At this point snap is available and seeding is at the point where
     # were snapd to installed and restarted successfully. Show progress
     # now. Even without showing progress we *must* wait here until


### PR DESCRIPTION
After discussing internally we decided that we need the snapd.seeded
unit in the core snap. It is an interface that external groups may
use and that is also used internally by cloud-config.service.

This PR adds a very simple systemd unit to core18. It will run
after core18.start-snapd has finished at which point the system
is fully seeded on UC18. This ensures that the sematnic of the
unit is correct.

During the seeding the unit is replaced with the right one from
snapd (in /etc/systemd/system/snapd.seeded). This means we can
remove the rather nasty hack to restart snapd.seeeded in the
core18.start-snapd unit because `snap wait` will not start until
snapd is ready (because of the After=core18.start-snapd clause).