### PR TITLE
static: add missing /lib/udev/rules.d/66-snapd-autoimport.rules

### DIFF
--- a/static/lib/udev/rules.d/66-snapd-autoimport.rules
+++ b/static/lib/udev/rules.d/66-snapd-autoimport.rules
@@ -1,0 +1,3 @@
+# probe for assertions, must run before udisks2
+ACTION=="add", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*" \
+    RUN+="/usr/bin/unshare -m /usr/bin/snap auto-import --mount=/dev/%k"


### PR DESCRIPTION
This adds the missing udev auto-import rules to core18 so that
e.g. the system user assertion works again in UC18.