### PR TITLE
static: run snapd for the first time with systemd-run

### DIFF
--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -21,14 +21,17 @@ run_on_unseeded() {
     trap "umount $TMPD; rmdir $TMPD" EXIT
     mount "$SEED_SNAPD" "$TMPD"
 
-    # snapd will write all the needed snapd.{service,socket}
-    # units and restart once it seeded the snapd snap
-    "$TMPD"/usr/lib/snapd/snapd
-
-    # ensure the snapd.socket gets restarted after seeding, the
-    # snapd binary in seeding runs without systemd sockets and
-    # will delete its the socket files it created on exit.
-    systemctl restart snapd.socket || true
+    # snapd will write all its needed snapd.{service,socket}
+    # units and restart once it seeded the snapd snap. We create
+    # a systemd socket unit so that systemd own the socket, otherwise
+    # the socket file would be removed by snapd on exit and the snapd.seeded
+    # service will fail because it has nothing to talk to anymore.
+    systemd-run --unit=snapd-seeding --service-type=notify --socket-property ListenStream=/run/snapd.socket --socket-property ListenStream=/run/snapd-snap.socket "$TMPD"/usr/lib/snapd/snapd
+    # we need to start the snapd service from above explicitly, systemd-run
+    # only enables the socket but does not start the service.
+    systemctl start --wait snapd-seeding.service
+    # at this point the snapd.socket is available
+    systemctl stop snapd-seeding.socket
 
     # At this point snap is available and seeding is at the point where
     # were snapd to installed and restarted successfully. Show progress


### PR DESCRIPTION
So far we ran the snapd for the first time wihtout systemd. This
has the undesired side-effect that snapd creates the snapd.socket
file and when it exists this file gets removed by the golang runtime.

This causes all sorts of problems because the snapd.seeded service
tries to talk to a socket file that got removed. By using systemd
we get a socket file that is managed by systemd and not removed
which fixes the issues that snapd.seeded explodes.