### PR TITLE
static: add ds-identify.cfg back

### DIFF
--- a/static/etc/cloud/ds-identify.cfg
+++ b/static/etc/cloud/ds-identify.cfg
@@ -1,0 +1,2 @@
+policy: search,found=first,maybe=none,notfound=disabled
+ci.datasource.ec2.strict_id=true


### PR DESCRIPTION
This adds the UC16 ds-identify.cfg back.