### PR TITLE
static,hooks: make /etc/cloud a "synced" dir for now

### DIFF
--- a/hooks/991-no-synced-dirs.chroot
+++ b/hooks/991-no-synced-dirs.chroot
@@ -1,5 +1,9 @@
 #!/bin/sh -ex
 
+#FIXME: once the we no longer write an empty /writable/system-data/etc/cloud 
+#       we can re-enable this test
+exit 0
+
 if grep -v '^#' </etc/system-image/writable-paths | grep synced; then
     echo "Using 'synced' in /etc/system-image/writable-paths is not allowed in core18"
     exit 1

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -52,7 +52,12 @@
 /var/lib/dbus                           auto                    persistent  none        none
 /var/lib/dhcp                           auto                    persistent  none        none
 # cloud-init
-/etc/cloud                              auto                    persistent  transition  none
+# FIXME: we currently write an empty /writable/system-data/etc/cloud directory
+#        when creating the image.  So setting /etc/cloud to  "persistent"
+#        instead of "synced" will result all writes getting skipped. Once
+#        the image does no longer contains this empty dir this patch can be
+#        reverted.
+/etc/cloud                              auto                    synced      none        none
 /var/lib/cloud                          auto                    persistent  none        none
 # for various clouds like GCE
 /etc/sysctl.d                           auto                    persistent  transition  none


### PR DESCRIPTION
We write an empty /writable/system-data/etc/cloud directory into
the UC18 image. This means that the code that processes the
"transition" dirs assumes the content was already copied and skips
this dir. Using "synced" unbreaks things.

Once we have removed the creation of this dir during image bulding
we can revert this patch again.

This is actually more complicated and we may need to keep "synced"
because ubuntu-image provides a way to pass a cloud config file. However
*if* that file gets passed and is written the rest of the dir won't be synced
anymore (no ds-identify.cfg etc). So we need to think about this some more.