### PR TITLE
As per what we did in core16, remove dbus's machine-id.

### DIFF
--- a/hooks/003-remove-dbus-machine-id.chroot
+++ b/hooks/003-remove-dbus-machine-id.chroot
@@ -4,7 +4,7 @@ set -e
 
 # Remove dbus machine id.
 #
-# This removes dbus machine id that cache that makes each system unique.
+# This removes dbus machine id that makes each system unique.
 
 rm -f /var/lib/dbus/machine-id
 

--- a/hooks/003-remove-dbus-machine-id.chroot
+++ b/hooks/003-remove-dbus-machine-id.chroot
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+# Remove dbus machine id.
+#
+# This removes dbus machine id that cache that makes each system unique.
+
+rm -f /var/lib/dbus/machine-id
+
+# truncate, do not remove otherwise systemd is unhappy
+printf "" > /etc/machine-id
+


### PR DESCRIPTION
For core/core16 we used live-build to create the rootfs and apparently the removal of machine-id was done through livecd-rootfs, not our ubuntu-core specific hooks (i.e. the remove-dbus-machine-id chroot hook was being added through auto/config).
We now need to do this in our custom hooks after dbus is installed.