### PR TITLE
hooks: add /var/lib/jenkins for compat

### DIFF
--- a/hooks/020-extra-files.chroot
+++ b/hooks/020-extra-files.chroot
@@ -35,3 +35,8 @@ mkdir -p /var/lib/cloud
 
 echo "ensure snapctl is available"
 ln -s ../lib/snapd/snapctl /usr/bin/snapctl
+
+# FIXME: this can go once we support non /home dirs directly
+echo "creating jenkins compat home"
+mkdir -p /var/lib/jenkins
+


### PR DESCRIPTION
The 2.37 release has a regression for people using homedirs in
/var/lib/*. The most prominent example is jenkins. To quickly
unblock that we need this dir and
 https://github.com/snapcore/snapd/pull/6446

While core18 is not affected as such having this will also
allow jenkins to use core18 snaps. This will eventually be
removed when we have proper (and general) non /home
support.