### PR TITLE
Support arm64 with efi bootloader

### DIFF
--- a/hooks/016-ensure-bootloaders.chroot
+++ b/hooks/016-ensure-bootloaders.chroot
@@ -4,6 +4,7 @@ echo "Create the boot mount points"
 mkdir -p /boot/androidboot
 mkdir -p /boot/uboot
 mkdir -p /boot/grub
+mkdir -p /boot/efi
 
 echo "Add uboot config on arm"
 case "$(dpkg --print-architecture)" in
@@ -19,8 +20,5 @@ case "$(dpkg --print-architecture)" in
 /boot/uboot/uboot.env 0x0000 0x20000
 /boot/uboot/uboot.env 0x0000 0x20000
 EOF
-        ;;
-    amd64|i386)
-        mkdir /boot/efi
         ;;
 esac


### PR DESCRIPTION
There is a arm64 system with efi boot and currently it failed to boot
uc18 due to ubuntu-core-rootfs of initramfs lost ${rootmnt}/boot/efi,
where it wasn't created from core18 snap. To consider this case, core18
should make sure /boot/efi can be built with the same hook.