### PR TITLE
Backport wpa_supplicant.service.d/snap.conf from core

### DIFF
--- a/static/lib/systemd/system/wpa_supplicant.service.d/snap.conf
+++ b/static/lib/systemd/system/wpa_supplicant.service.d/snap.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=!/etc/systemd/system/snap.wpa-supplicant.wpa.service


### PR DESCRIPTION
This enables running wpa-supplicant from a snap instead of the built-in one.

Currently I do not see a wpa-supplicant for core18 so this PR doesn't have to be merged instantly - not sure if there's actually need for that. Still, it's a feature that was available in core16 so we should at least consider including it in core18 as well.