### PR TITLE
hooks: remove /etc/apt/sources.list.d/proposed.list

### DIFF
--- a/hook-tests/001-extra-packages.test
+++ b/hook-tests/001-extra-packages.test
@@ -8,13 +8,6 @@
 
 set -e
 
-output="$(find /etc/apt/sources.list.d/ -type f -printf "%f\n")"
-if [ "$output" != "ubuntu-image.list" ];then
-    echo "Extra sources.list.d components found: "
-    echo "$output"
-    exit 1
-fi
-
 if [ "$(dpkg --print-architecture)" != "amd64" ]; then
     echo "only testing on amd64 for now"
     exit 0

--- a/hook-tests/001-extra-packages.test
+++ b/hook-tests/001-extra-packages.test
@@ -8,6 +8,13 @@
 
 set -e
 
+output="$(find /etc/apt/sources.list.d/ -type f -printf "%f\n")"
+if [ "$output" != "ubuntu-image.list" ];then
+    echo "Extra sources.list.d components found: "
+    echo "$output"
+    exit 1
+fi
+
 if [ "$(dpkg --print-architecture)" != "amd64" ]; then
     echo "only testing on amd64 for now"
     exit 0

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -4,6 +4,14 @@ set -eux
 
 export DEBIAN_FRONTEND=noninteractive
 
+# TODO: work with foundation to not have PROPOSED=1 when building the
+#       bionic-base tarfiles. Right now we still get some packages from
+#       proposed presumably if they are part of the initial debootstrap.
+#
+# ensure we don't use proposed for new installs
+rm -f /etc/apt/sources.list.d/proposed.list
+
+
 # ensure we have /proc or systemd will fail
 mount -t proc proc /proc
 trap 'umount /proc' EXIT


### PR DESCRIPTION
The "bionic-base.tar.xz" we get from cdimage is build with
bionic-prposed enabled by default. This is problematic for us
because core18 is meant to be build from stable only.

This PR removes it for all the extra pacakges we install. We
need to double check with foundations that the bionic-base.tar.xz
is also build from stable only but that is outside the scope of
this PR.