### PR TITLE
hooks: reduce snapd skeleton directories

### DIFF
--- a/hook-tests/041-snapd-skeleton.test
+++ b/hook-tests/041-snapd-skeleton.test
@@ -1,25 +1,5 @@
 #!/bin/sh -ex
 
-# There are several directories present
+# The snapd integration mount points are present.
 test -d var/cache/snapd
-test -d var/lib/snapd/apparmor
-test -d var/lib/snapd/apparmor/profiles
-test -d var/lib/snapd/apparmor/snap-confine
-test -d var/lib/snapd/assertions
-test -d var/lib/snapd/cache
-test -d var/lib/snapd/cookie
-test -d var/lib/snapd/desktop/applications
-test -d var/lib/snapd/device
-test -d var/lib/snapd/hostfs
-test -d var/lib/snapd/lib/gl
-test -d var/lib/snapd/lib/gl32
-test -d var/lib/snapd/lib/glvnd
-test -d var/lib/snapd/lib/vulkan
-test -d var/lib/snapd/mount
-test -d var/lib/snapd/seccomp/bpf
-test -d var/lib/snapd/sequence
-test -d var/lib/snapd/snaps
-test -d var/lib/snapd/void
-
-# The void directory has special permissions
-test "$(stat -c %a var/lib/snapd/void)" = 111
+test -d var/lib/snapd

--- a/hooks/700-snapd-tree-skeleton.chroot
+++ b/hooks/700-snapd-tree-skeleton.chroot
@@ -1,23 +1,10 @@
 #!/bin/sh -ex
-# This sequence is modelled after snapd's packaging/snapd.mk it also contains
-# the important "void" directory, along with the special permissions it
-# carries.
-echo "I: Creating snapd skeleton directory structure"
+# The directories created here are not the full set needed by snapd but given
+# the way core18 + snapd booting looks like, they are not used anyway. On a
+# core18 system /var/lib/snapd and /var/cache/snapd are bind-mounts to
+# directories in /writable/system-data/ - as such nothing beyond the mount
+# points is used.
+
+echo "I: Creating snapd mount points"
 install -m 755 -d var/cache/snapd
-install -m 755 -d var/lib/snapd/apparmor/profiles
-install -m 755 -d var/lib/snapd/apparmor/snap-confine
-install -m 755 -d var/lib/snapd/assertions
-install -m 755 -d var/lib/snapd/cache
-install -m 755 -d var/lib/snapd/cookie
-install -m 755 -d var/lib/snapd/desktop/applications
-install -m 755 -d var/lib/snapd/device
-install -m 755 -d var/lib/snapd/hostfs
-install -m 755 -d var/lib/snapd/lib/gl
-install -m 755 -d var/lib/snapd/lib/gl32
-install -m 755 -d var/lib/snapd/lib/glvnd
-install -m 755 -d var/lib/snapd/lib/vulkan
-install -m 755 -d var/lib/snapd/mount
-install -m 755 -d var/lib/snapd/seccomp/bpf
-install -m 755 -d var/lib/snapd/sequence
-install -m 755 -d var/lib/snapd/snaps
-install -m 111 -d var/lib/snapd/void
+install -m 755 -d var/lib/snapd


### PR DESCRIPTION
Given that core18 + snapd boots with bind mounts for /var/lib/snapd and
/var/cache/snapd that go into the /writable partition, nothing created
underneath the afforementioned directories matters.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>