### PR TITLE
gpg (dirmngr actually) panics when there's no random/urandom.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,13 @@ install:
 	tar -x -f ../$(BASE) -C $(DESTDIR)
 	# ensure resolving works inside the chroot
 	cat /etc/resolv.conf > $(DESTDIR)/etc/resolv.conf
+	# since recently we're also missing some /dev files that might be
+	# useful during build - make sure they're there
+	[ -e $(DESTDIR)/dev/null ] || mknod -m 666 $(DESTDIR)/dev/null c 1 3
+	[ -e $(DESTDIR)/dev/zero ] || mknod -m 666 $(DESTDIR)/dev/zero c 1 5
+	[ -e $(DESTDIR)/dev/random ] || mknod -m 666 $(DESTDIR)/dev/random c 1 8
+	[ -e $(DESTDIR)/dev/urandom ] || \
+		mknod -m 666 $(DESTDIR)/dev/urandom c 1 9
 	# copy static files verbatim
 	/bin/cp -a static/* $(DESTDIR)
 	# customize

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -14,10 +14,10 @@ rm -f /etc/apt/sources.list.d/proposed.list
 
 # ensure we have /proc or systemd will fail
 # we also need /dev/random and /dev/urandom for gpg not to bail
+trap 'umount /proc; rm -f /dev/random; rm -f /dev/urandom' EXIT
 mount -t proc proc /proc
 mknod /dev/random c 1 8
 mknod /dev/urandom c 1 9
-trap 'umount /proc; rm /dev/random; rm /dev/urandom' EXIT
 
 # systemd postinst needs this
 mkdir -p /var/log/journal

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -13,11 +13,8 @@ rm -f /etc/apt/sources.list.d/proposed.list
 
 
 # ensure we have /proc or systemd will fail
-# we also need /dev/random and /dev/urandom for gpg not to bail
-trap 'umount /proc; rm -f /dev/random; rm -f /dev/urandom' EXIT
 mount -t proc proc /proc
-mknod /dev/random c 1 8
-mknod /dev/urandom c 1 9
+trap 'umount /proc' EXIT
 
 # systemd postinst needs this
 mkdir -p /var/log/journal

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -13,8 +13,11 @@ rm -f /etc/apt/sources.list.d/proposed.list
 
 
 # ensure we have /proc or systemd will fail
+# we also need /dev/random and /dev/urandom for gpg not to bail
 mount -t proc proc /proc
-trap 'umount /proc' EXIT
+mknod /dev/random c 1 8
+mknod /dev/urandom c 1 9
+trap 'umount /proc; rm /dev/random; rm /dev/urandom' EXIT
 
 # systemd postinst needs this
 mkdir -p /var/log/journal


### PR DESCRIPTION
Currently core18 FTBFS. Not sure what changed that causes the issue (gnupg2 didn't, so I'd expect something in our ubuntu-base tarballs?), but now the hook which installs extra packages dies when trying to add the ubuntu-image PPA key to the keyring. It actually dies because dirmngr panics and exits because of missing /dev/urandom and /dev/random. The easiest way to fix it is simply creating the two special files exist for the run of the hook.