### PR TITLE
static: make /etc/writable transitional in "writable-paths"

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -22,7 +22,7 @@
 /tmp                                    none                    temporary   none        defaults
 /var/tmp                                auto                    persistent  transition  none
 # etc related
-/etc/writable                           auto                    persistent  none        none
+/etc/writable                           auto                    persistent  transition        none
 # apparmor
 /etc/apparmor.d/cache                   auto                    persistent  none        none
 # dbus system bus


### PR DESCRIPTION
The current /etc/writable/ dir is not populated because it
is not set to "transitional". This PR ensures the files/links
get created on the writable space.

Thanks to ogra for the report.