### PR TITLE
Add iptables into package list

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -41,6 +41,7 @@ apt install --no-install-recommends -y \
     tzdata \
     openssh-server \
     iproute2 \
+    iptables \
     kmod \
     udev \
     sudo \


### PR DESCRIPTION
This package was included in the core snap but lost in the transition to
core18.  It is required by the firewall-control interface which snapd
expects to be implemented by the base snap on an Ubuntu Core system.

Closes: #132