### PR TITLE
hooks: add apt/apt-get/apt-cache warning (based on mvo's branch)

### DIFF
--- a/hook-tests/601-create-apt-get-warning.test
+++ b/hook-tests/601-create-apt-get-warning.test
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+echo "All apt command should provide a failure"
+for cmd in apt apt-get apt-cache; do
+    ! chroot . $cmd > stdout
+    grep -q "Ubuntu Core does not use apt-get" stdout
+done

--- a/hooks/601-create-apt-get-warning.chroot
+++ b/hooks/601-create-apt-get-warning.chroot
@@ -1,0 +1,15 @@
+#!/bin/sh -ex
+
+echo "I: Creating warning to use snappy when apt-get is used"
+
+mkdir -p /usr/bin
+cat >/usr/bin/no-apt <<EOF
+#!/bin/sh
+echo "Ubuntu Core does not use apt-get, see 'snap --help'!"
+exit 1
+EOF
+chmod 755 /usr/bin/no-apt
+
+for cmd in apt apt-cache apt-get; do
+    ln -s no-apt /usr/bin/$cmd
+done


### PR DESCRIPTION
Add a message that apt/apt-get/apt-cache are not available on a Ubuntu Core system.

Based on https://github.com/snapcore/core18/pull/122 but with modifications.