### PR TITLE
Include dmsetup in the core18 snap

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -38,6 +38,7 @@ apt install --no-install-recommends -y \
     libpam-systemd \
     libpam-modules \
     distro-info-data \
+    dmsetup \
     tzdata \
     openssh-server \
     iproute2 \


### PR DESCRIPTION
The dmsetup package includes udev rules that are essential for any system
using device mapper, which includes any system using crypsetup and we want
to support full-disk encryption in Ubuntu Core.