### PR TITLE
Use snapcraft's now-non-default destructive mode for building on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ script:
   - sudo apt-get install --yes --no-install-recommends snapd
   - sudo snap wait system seed.loaded
   - sudo snap install --classic snapcraft
-  - sudo snapcraft
+  - sudo snapcraft --destructive-mode
   - make test


### PR DESCRIPTION
Currently travis CI fails as snapcraft wants to install multipass and expects running in an interactive mode. We actually don't need multipass, which would make the test runs much slower.