### PR TITLE
hooks: add missing dosfstools to get fsck.fat

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -48,7 +48,8 @@ apt install --no-install-recommends -y \
     console-conf \
     rfkill \
     wpasupplicant \
-    cloud-init
+    cloud-init \
+    dosfstools
 
 # since we installed what we wanted, let's get rid of the extra gnupg and all
 # its dependencies


### PR DESCRIPTION
This should also get a spread test later in core where we corrupt the /boot fat system and double check that it get fscked/repaired.