### PR TITLE
static: add /etc/environment to writable-paths

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -62,3 +62,5 @@
 /etc/sysctl.d                           auto                    persistent  transition  none
 # swapfile
 /etc/default/swapfile                   auto                    persistent  transition  none
+# allow system wide proxy setting
+/etc/environment                        auto                    persistent  transition  none


### PR DESCRIPTION
Ogra reported that /etc/environment is not writable on uc18 based
systems. This commit fixes this.