### PR TITLE
Add efibootmgr to the extra packages.

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -59,7 +59,8 @@ apt install --no-install-recommends -y \
     rfkill \
     wpasupplicant \
     cloud-init \
-    dosfstools
+    dosfstools \
+    efibootmgr
 
 # since we installed what we wanted, let's get rid of the extra gnupg and all
 # its dependencies


### PR DESCRIPTION
Paul from certification mentioned that we're missing efibootmgr on core18, even though it was around for core16. Prepared this PR to hear from people involved if we can enable it or not.