### PR TITLE
hooks/motd: cleanup dangling symlink, fix typo

### DIFF
--- a/hooks/014-set-motd.chroot
+++ b/hooks/014-set-motd.chroot
@@ -26,6 +26,7 @@ rm /etc/update-motd.d/60-unminimize
 
 # remove the motd-news service files
 rm /lib/systemd/system/motd-news.{service,timer}
+rm /etc/systemd/system/timers.target.wants/motd-news.timer
 
-# diable dynamic motd
+# disable dynamic motd
 sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news


### PR DESCRIPTION
Cleanup a dangling symlink to motd-news.timer which is already removed in hooks.