### PR TITLE
static: make /etc/dbus-1/session.d writable

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -25,7 +25,8 @@
 /etc/writable                           auto                    persistent  transition        none
 # apparmor
 /etc/apparmor.d/cache                   auto                    persistent  none        none
-# dbus system bus
+# dbus
+/etc/dbus-1/session.d                   auto                    persistent  transition  none
 /etc/dbus-1/system.d                    auto                    persistent  transition  none
 /etc/hosts                              auto                    persistent  transition  none
 /etc/iproute2                           auto                    persistent  transition  none


### PR DESCRIPTION
This supercedes for PR #98, and is intended for use by https://github.com/snapcore/snapd/pull/6258

In order to have dbus-daemon look for service activation files under `/var/lib/snapd`, we need to drop configuration fragments into `/etc/dbus-1/session.d` and `/etc/dbus-1/system.d`.  The latter was already writable so the dbus interface can poke holes in the system bus security policy, but the former was not.

I've simply added the `session.d` directory here, but an alternative would be to simply make all of `/etc/dbus-1` writable, which would save a bind mount.  The downside of that is that on transition the `/etc/dbus-1/session.d` directory might go missing.  That is unlikely to cause problems though because:

1. Ubuntu Core devices don't tend to run a session bus.

2. dbus-daemon's configuration file parser does not treat a missing `<includedir>` as an error: https://gitlab.freedesktop.org/dbus/dbus/-/blob/master/bus/config-parser.c#L2478