### PR TITLE
Make .disk/info visible on the root partition

### DIFF
--- a/hook-tests/021-link-disk-info.test
+++ b/hook-tests/021-link-disk-info.test
@@ -1,3 +1,3 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 
-test -L /.disk
+test -L .disk

--- a/hook-tests/021-link-disk-info.test
+++ b/hook-tests/021-link-disk-info.test
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+test -L /.disk

--- a/hooks/021-link-disk-info.chroot
+++ b/hooks/021-link-disk-info.chroot
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+set -e
+
+echo "create a persistent link for .disk/info" >&2
+ln -sf /writable/.disk /.disk

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,6 +14,10 @@ parts:
     build-packages:
       - shellcheck
       - wget
+    # XXX: snapcraft by default doesn't stage hidden (.) files and directories,
+    # so we need to explicitly list the .disk file for it to get staged/primed.
+    stage: [ .disk, ./* ]
+    prime: [ .disk, ./* ]
     # XXX: Dirty hacks to enable building core18 on non-bionic systems.
     # Without these overrides both the PATH and LD_LIBRARY_PATH contain paths
     # in the part's install directory which binaries can be incompatible with


### PR DESCRIPTION
Ok, bare with me here for a minute, this is just one possibility - I know this basically sucks and is not the cleanest solution of all. Basically the problem here is: we have a .disk/info file in /writable/.disk/info with the image build info that we'd like to export in the root directory since we already have far too many places where users have to look for this file. There's a few ways we can do this, two of them are:

1) Create a permanent symlink on the root partition to /writable/.disk/. The plus-side of it is that it's simple and non-invasive. The down-side of it is that if /writable/.disk/ does not exist, we basically have a dangling broken symlink in /. I don't think this is too big of a problem as this file is hidden by default anyway.

2) Bind-mount /writable/.disk to /.disk. We could do that via fstab (though we wanted to have it empty on the base system) or by having a service do that dynamically on startup. The latter is nice because we could bind-mount it only if /writable/.disk/ exists, so no more dangling symlinks or other ugliness. The problem though is that this requires hackery for such a small thing like a /.disk/info file.

I went here with choice 1, but we could go for 2 as well. We could also screw it and just point people to /writable/.disk/info, but I heard some people complaining about it.