### PR TITLE
hooks: fix broken symlink /etc/sysctl.conf.d/99-sysctl.conf

### DIFF
--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -23,7 +23,12 @@ rm /etc/pam.conf
 rm -rf /etc/profile.d
 
 rm /etc/rmt
+
+# sysctl.conf is not writable and everything in there is commented out
 rm /etc/sysctl.conf
+# 99-sysctl.conf is a symlink to /etc/sysctl.conf
+rm /etc/sysctl.conf.d/99-sysctl.conf
+
 rm -rf /etc/terminfo
 rm -rf /etc/tmpfiles.d
 

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -27,7 +27,7 @@ rm /etc/rmt
 # sysctl.conf is not writable and everything in there is commented out
 rm /etc/sysctl.conf
 # 99-sysctl.conf is a symlink to /etc/sysctl.conf
-rm /etc/sysctl.conf.d/99-sysctl.conf
+rm /etc/sysctl.d/99-sysctl.conf
 
 rm -rf /etc/terminfo
 rm -rf /etc/tmpfiles.d


### PR DESCRIPTION
Core currently has a symlink /etc/sysctl.conf.d/99-sysctl.conf that
points to /etc/sysctl.conf. This file is removed by the core build
so removing this symlink is also needed.

Note that the sysctl.conf file is not writable on core and it
only contains commented out entries.