### PR TITLE
Add motd and issue to writable /etc files

### DIFF
--- a/hook-tests/008-etc-writable.test
+++ b/hook-tests/008-etc-writable.test
@@ -6,6 +6,8 @@ echo "Ensure links worked"
 test -e etc/timezone
 test -e etc/localtime
 test -e etc/hostname
+test -e etc/motd
+test -e etc/issue
 grep -q "Etc/UTC" etc/timezone
 test $(readlink etc/localtime) = "writable/localtime"
 test $(readlink etc/writable/localtime) = "/usr/share/zoneinfo/Etc/UTC"

--- a/hooks/008-etc-writable.chroot
+++ b/hooks/008-etc-writable.chroot
@@ -4,7 +4,7 @@ mkdir -p /etc/writable/default
 
 # cloud-init needs to be able to modify hostname and has the ability to
 # set the other two.
-for f in timezone localtime hostname; do
+for f in timezone localtime hostname motd issue; do
     if [ -e /etc/$f ]; then
         echo "I: Moving /etc/$f to /etc/writable/"
         mv /etc/$f /etc/writable/$f


### PR DESCRIPTION
As an embedded developer, I'd like to be able to modify my `motd` and `issue` banners with a config hook when installing my Ubuntu Core image. Because these files are unwritable currently, It appears I straight-up cannot do that, so, I'd like to add them to the `writable` directory so that they can be modified.