### PR TITLE
030-fix-timedatectl.chroot: fix quoting issues

### DIFF
--- a/hooks/030-fix-timedatectl.chroot
+++ b/hooks/030-fix-timedatectl.chroot
@@ -18,18 +18,18 @@ TIMEDATECTL=/usr/bin/timedatectl.real
 
 case $1 in
     set-timezone)
-        $TIMEDATECTL set-timezone $2
+        $TIMEDATECTL set-timezone "$2"
         # do special handling on core devices (there /etc/localtime
         # is a symlink to /etc/writable/localtime)
         if [ -L /etc/writable/localtime ]; then
             # make a .tmp link and mv it to have "kind of" atomic
             # writing here in case of a power loss midway through
-            ln -s /usr/share/zoneinfo/$2 /etc/writable/localtime.tmp
+            ln -s /usr/share/zoneinfo/"$2" /etc/writable/localtime.tmp
             mv /etc/writable/localtime.tmp /etc/writable/localtime
         fi
         ;;
     *)
-        $TIMEDATECTL $@
+        $TIMEDATECTL "$@"
         ;;
 esac
 EOF


### PR DESCRIPTION
For some reason we did not include this core fix: https://github.com/snapcore/core/pull/64/commits/054f0dc8078d356b3abd83b460d0753202d3878c in core18.

Thanks to @ogra1 