### PR TITLE
hooks/001-extra-packages.chroot: add gdbserver

### DIFF
--- a/hook-tests/001-extra-packages.test
+++ b/hook-tests/001-extra-packages.test
@@ -38,6 +38,7 @@ e2fsprogs
 fdisk
 findutils
 gcc-8-base:amd64
+gdbserver
 gpgv
 grep
 gzip

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -60,7 +60,8 @@ apt install --no-install-recommends -y \
     rfkill \
     wpasupplicant \
     cloud-init \
-    dosfstools
+    dosfstools \
+    gdbserver
 
 # since we installed what we wanted, let's get rid of the extra gnupg and all
 # its dependencies


### PR DESCRIPTION
gdbserver is needed in order to use the new `snap run --experimental-gdbserver` feature. Specifically, using gdbserver is much smaller than adding the full gdb package to the base snap, and allows remote gdb debugging on Ubuntu Core.

See also https://forum.snapcraft.io/t/new-experimental-snap-run-experimental-gdbserver-option/18227

See also [this PR](https://github.com/snapcore/core20/pull/76) for the associated core20 PR.