### PR TITLE
Cleanup /run in the core.

### DIFF
--- a/hook-tests/900-cleanup-etc-var.test
+++ b/hook-tests/900-cleanup-etc-var.test
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+if [ -n "$(find run/ -type f)" ]; then
+    echo "/run must be empty in the image"
+    exit 1
+fi

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -67,3 +67,6 @@ mkdir -p /usr/local/share/fonts
 rm -rf /var/cache/debconf
 
 # FIXME: make /etc/lsb-release point to ../usr/lib/lsb-release
+
+# drop all of /run, it must be empty before boot
+rm -rf /run/*

--- a/hooks/999-clean-resolv-conf.chroot
+++ b/hooks/999-clean-resolv-conf.chroot
@@ -2,4 +2,6 @@
 
 set -e
 
-echo "" > /etc/resolv.conf
+rm -f /etc/resolv.conf
+
+ln -sf ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf


### PR DESCRIPTION
resolv.conf must be a symlink, note target is now gone, as /run is clean.

This resolves core18 FTBFS due to unable to prime unix pipe files in /run.