### PR TITLE
hooks: adapt to motd-news-config not being included in image any more

### DIFF
--- a/hook-tests/014-set-motd.test
+++ b/hook-tests/014-set-motd.test
@@ -4,9 +4,8 @@ set -e
 
 grep -q "This Ubuntu Core 18 machine is a tiny" etc/motd
 
+test ! -e etc/default/motd-news
 test ! -e etc/update-motd.d/10-help-text
 test ! -e etc/update-motd.d/60-unminimize
 test ! -e lib/systemd/system/motd-news.service
 test ! -e lib/systemd/system/motd-news.timer
-
-grep -q "ENABLED=0" etc/default/motd-news

--- a/hooks/014-set-motd.chroot
+++ b/hooks/014-set-motd.chroot
@@ -27,6 +27,3 @@ rm /etc/update-motd.d/60-unminimize
 # remove the motd-news service files
 rm /lib/systemd/system/motd-news.{service,timer}
 rm /etc/systemd/system/timers.target.wants/motd-news.timer
-
-# disable dynamic motd
-sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news


### PR DESCRIPTION
This is the same fix as https://github.com/snapcore/core20/pull/85, as it appears to affect core18 too.  The new `base-files` update associated with [bug #1888575][0] splits out the configuration file for the `motd-news` feature into a separate package.  That package does not end up in the image, causing the build to break.

As the hooks attempt to disable `motd-news` and the feature is disabled when the config file is absent, I've removed the code that attempts to patch the config file and added a test to ensure the config file is absent.

[0]: https://bugs.launchpad.net/ubuntu/+source/base-files/+bug/1888575