### PR TITLE
snapcraft.yaml: use build-base for modern snapcraft, and use lxd in travis to build the snap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,29 @@
-language: python
+language: minimal
 os: linux
-dist: xenial
+dist: bionic
 sudo: enabled
+addons:
+  snaps:
+    - name: snapcraft
+      confinement: classic
+    - name: lxd
+env:
+  global:
+    - LC_ALL=C.UTF-8
+    - LANG=C.UTF-8
+    # we could build natively w/o using lxd since travis supports bionic as a
+    # "dist", but since core18 devs may want to build local versions on systems
+    # other than bionic they will want to use lxd, so using it here makes sure
+    # that continues to work
+    - SNAPCRAFT_BUILD_ENVIRONMENT=lxd
+
+install:
+  - sudo apt-get remove lxd-client lxc -y
+  - sudo apt-get autoremove
+  - sudo /snap/bin/lxd init --auto
+  - sudo usermod --append --groups lxd $USER
+
 script:
-  - sudo apt-get update
-  - sudo apt-get install --yes --no-install-recommends snapd
-  - sudo snap wait system seed.loaded
-  - sudo snap install --classic snapcraft
-  - sudo snapcraft --destructive-mode
+  - sg lxd 'snapcraft'
+  - sudo unsquashfs -d prime core18*.snap
   - make test

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,14 +1,14 @@
 name: core18
-# version: 18
-adopt-info: boostrap
+adopt-info: bootstrap
 summary: Runtime environment based on Ubuntu 18.04
 description: |
   The base snap based on the Ubuntu 18.04 release.
 confinement: strict
 type: base
+build-base: core18
 
 parts:
-  boostrap:
+  bootstrap:
     plugin: make
     source: .
     build-packages:
@@ -16,8 +16,8 @@ parts:
       - wget
     # XXX: snapcraft by default doesn't stage hidden (.) files and directories,
     # so we need to explicitly list the .disk file for it to get staged/primed.
-    stage: [ .disk, ./* ]
-    prime: [ .disk, ./* ]
+    stage: [.disk, ./*]
+    prime: [.disk, ./*]
     # XXX: Dirty hacks to enable building core18 on non-bionic systems.
     # Without these overrides both the PATH and LD_LIBRARY_PATH contain paths
     # in the part's install directory which binaries can be incompatible with


### PR DESCRIPTION
This enables building with lxd or multipass using a modern snapcraft.

Additionally, fix a typo, delete the commented out version key, and adjust
whitespace as per a yaml linter (https://github.com/redhat-developer/vscode-yaml).

Finally, actually use lxd to build the snap on travis.