### PR TITLE
Add rng tools

### DIFF
--- a/hook-tests/001-extra-packages.test
+++ b/hook-tests/001-extra-packages.test
@@ -114,6 +114,7 @@ ncurses-bin
 passwd
 perl-base
 procps
+rng-tools
 sed
 sensible-utils
 systemd

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -60,6 +60,7 @@ apt install --no-install-recommends -y \
     console-conf \
     rfkill \
     wpasupplicant \
+    rng-tools \
     cloud-init \
     dosfstools \
     gdbserver


### PR DESCRIPTION
OK so.  This would immediately help many PI models that have a HWRNG and find themselves exhausting their entropy too quickly.  I've run in to this several times and from some googles I've seen this is very much a problem.  Raspberry Pi OS adds this as a base package as well in order to address this issue.

As it happens - many IOT boards offer a stable HWRNG.  It may be useful to catalog and get a view of which rng-tools variant would be best suited for this.

I am sending in this pull request to avoid maintaining a snap for this and offer overall stability to the community.