### PR TITLE
hook-tests: fix leaked /stdout file and add test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ test:
 				exit 1; \
 			fi; \
 	    	done; \
+	# no extra files in the rootdir
+	set -ex; find $(TESTDIR) -maxdepth 1 -type f -print -execdir false {} +
 
 # Display a report of files that are (still) present in /etc
 .PHONY: etc-report

--- a/hook-tests/601-create-apt-get-warning.test
+++ b/hook-tests/601-create-apt-get-warning.test
@@ -6,4 +6,5 @@ echo "All apt command should provide a failure"
 for cmd in apt apt-get apt-cache; do
     ! chroot . $cmd > stdout
     grep -q "Ubuntu Core does not use apt-get" stdout
+    rm -f stdout
 done


### PR DESCRIPTION
Ironically one of the tests create a stray /stdout file in current
core18 snaps. This commit fixes this and also adds code that checks
that "/" has no file in it as part of the "make test" command.