### PR TITLE
Update build instructions for other architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ For i386 and amd64
 $ sudo snapcraft
 ```
 
-For any other architecture we recommend remote-build as multipass has very limited
-support for cross-building, and other architectures. To use remote-build you need to 
-have a launchpad account, and follow the instructions [here](https://snapcraft.io/docs/remote-build)
+For any other architecture we recommend remote-build as multipass has limited
+support for cross-building, and lack of stable releases for some architectures. 
+To use remote-build you need to have a launchpad account, and follow the instructions [here](https://snapcraft.io/docs/remote-build)
 ```
 $ sudo snapcraft remote-build --build-on={arm64,armhf,ppc64el,s390x}
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a base snap for snapd that is based on Ubuntu 18.04
 
 # Building locally
 
-To build this snap locally you need snapcraft. The project must be built as real root. 
+To build this snap locally you need snapcraft. The project must be built as real root.
 
 For i386 and amd64
 ```

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@ This is a base snap for snapd that is based on Ubuntu 18.04
 
 # Building locally
 
-To build this snap locally you need snapcraft. The project must be built as real root.
+To build this snap locally you need snapcraft. The project must be built as real root. 
 
+For i386 and amd64
 ```
 $ sudo snapcraft
+```
+
+For any other architecture we recommend remote-build as multipass has very limited
+support for cross-building, and other architectures. To use remote-build you need to 
+have a launchpad account, and follow the instructions [here](https://snapcraft.io/docs/remote-build)
+```
+$ sudo snapcraft remote-build --build-on={arm64,armhf,ppc64el,s390x}
 ```
 
 # Writing code


### PR DESCRIPTION
Due to missing stable multipass releases on platforms like the raspberry pi (armhf), I've added instructions on how to do remote builds for these platforms as that works without any issues. I just verified that this is an issue on my own Pi4. 

Feel free to correct me, or enlighten me if I've missed anything. 

This is in part to address #162 