### PR TITLE
Handle PPAs being served from ppa.launchpadcontent.net

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -25,7 +25,7 @@ apt update
 apt install --no-install-recommends -y gnupg
 
 # enable the foundations ubuntu-image PPA
-echo "deb http://ppa.launchpad.net/canonical-foundations/ubuntu-image/ubuntu bionic main" > /etc/apt/sources.list.d/ubuntu-image.list
+echo "deb http://ppa.launchpadcontent.net/canonical-foundations/ubuntu-image/ubuntu bionic main" > /etc/apt/sources.list.d/ubuntu-image.list
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CDE5112BD4104F975FC8A53FD4C0B668FD4C9139
 
 # install some packages we need

--- a/hooks/600-no-debian.chroot
+++ b/hooks/600-no-debian.chroot
@@ -15,7 +15,7 @@ dpkg -l > usr/share/snappy/dpkg.list
 # fill in ppa information in yaml file
   printf 'package-repositories:\n'
   find etc/apt/ -name \*.list | while IFS= read -r APT; do
-    grep -o "^deb http://ppa.launchpad.net/[a-z0-9\.\+\-]\+/[a-z0-9\.\+\-]\+/[a-z0-9\.\+\-]\+" "$APT" | while read -r ENTRY ; do
+    grep -Eo "^deb https?://ppa\.launchpad(content)?\.net/[a-z0-9\.\+\-]+/[a-z0-9\.\+\-]+/[a-z0-9\.\+\-]+" "$APT" | while read -r ENTRY ; do
       USER=$(echo "$ENTRY" | cut -d/ -f4)
       PPA=$(echo "$ENTRY" | cut -d/ -f5)
       DISTRO=$(echo "$ENTRY" | cut -d/ -f6)


### PR DESCRIPTION
We now have a new HTTPS-capable domain for public PPAs, namely
ppa.launchpadcontent.net.  Adjust various bits of the build system to
accept that.