### PR TITLE
run-snapd-from-snap: set the current symlink before bootstrapping

### DIFF
--- a/static/usr/lib/core18/run-snapd-from-snap
+++ b/static/usr/lib/core18/run-snapd-from-snap
@@ -21,6 +21,13 @@ run_on_unseeded() {
     trap "umount $TMPD; rmdir $TMPD" EXIT
     mount "$SEED_SNAPD" "$TMPD"
 
+    # We need to initialize /snap/snapd/current symlink so that the
+    # dynanic linker
+    # /snap/snapd/current/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+    # is available to run snapd.
+    [ -d /snap/snapd ] || mkdir -p /snap/snapd
+    ln -sf "${TMPD}" /snap/snapd/current
+
     # snapd will write all its needed snapd.{service,socket}
     # units and restart once it seeded the snapd snap. We create
     # a systemd socket unit so that systemd own the socket, otherwise


### PR DESCRIPTION
This is needed by https://github.com/snapcore/snapd/pull/13370