### PR TITLE
snapcraft.yaml: add assumes for snapd 2.61

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -6,6 +6,9 @@ description: |
 confinement: strict
 type: base
 build-base: core18
+# Ensure snapd with apparmor service
+assumes:
+  - snapd2.61
 
 parts:
   bootstrap:


### PR DESCRIPTION
This is necessary as the apparmor package does not include anymore bits needed by older snapd.