### PR TITLE
tools/generate-changelog.py: work-around esm re-upload of distro-info-data

### DIFF
--- a/tools/generate-changelog.py
+++ b/tools/generate-changelog.py
@@ -40,9 +40,11 @@ from collections import namedtuple
 # keep the list short to not increase the time it takes
 # to generate changelogs
 pkg_allowed_list = [
-    'apt',            # removed during hook
-    'libapt-pkg5.0',  # removed during hook
-    'debconf'         # removed during hook
+    'apt',              # removed during hook
+    'libapt-pkg5.0',    # removed during hook
+    'debconf',          # removed during hook
+    'distro-info-data', # ESM re-uploaded the exact same version of the package
+                        # but without the changelog. Shame!
 ]
 
 


### PR DESCRIPTION
It seems that ESM has the same version of distro-info-data, but still modified, without the changelog file. So let's work-around that by fetching the changelog from the URL.