### PR TITLE
hooks: add script to remove unneeded apparmor profiles

### DIFF
--- a/hook-tests/800-remove-unneeded-profiles.test
+++ b/hook-tests/800-remove-unneeded-profiles.test
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+set -x
+APPARMOR_PROF_D="etc/apparmor.d"
+
+declare -A allowed_profs
+
+num_prof=0
+
+for profile in "$APPARMOR_PROF_D"/*; do
+    # Skip if it is a directory
+    if [ -d "$profile" ]; then
+        continue
+    fi
+    # Skip if not a regular file
+    if [ ! -f "$profile" ]; then
+        continue
+    fi
+    num_prof=$((num_prof + 1))
+
+    filename=$(basename "$profile")
+    if ! [[ -v allowed_profs["$filename"] ]]; then
+        printf "Apparmor profile %s is not allowed\n" "$filename"
+        exit 1
+    fi
+done
+
+if [ "$num_prof" -ne "${#allowed_profs[@]}" ]; then
+    # If there were more we would have failed in the loop
+    printf "Less number of apparmor profiles than expected\n"
+    exit 1
+fi

--- a/hooks/800-remove-unneeded-profiles.chroot
+++ b/hooks/800-remove-unneeded-profiles.chroot
@@ -1,0 +1,54 @@
+#!/bin/bash -ex
+
+# Check profiles in /etc/apparmor.d/ and removes them if no matching binary
+# exists.
+
+APPARMOR_PROF_D="/etc/apparmor.d"
+
+# The list of directories to check for binaries
+SEARCH_DIRS=(
+    "/usr/bin"
+    "/usr/sbin"
+    "/usr/lib/systemd"
+    "/usr/lib/snapd"
+    "/usr/lib/cargo/bin"
+)
+
+echo "Starting AppArmor profile cleanup..."
+
+# Iterate through files in /etc/apparmor.d/
+for profile in "$APPARMOR_PROF_D"/*; do
+    # Skip if it is a directory
+    if [ -d "$profile" ]; then
+        continue
+    fi
+    # Skip if not a regular file
+    if [ ! -f "$profile" ]; then
+        continue
+    fi
+
+    filename=$(basename "$profile")
+
+    # unix-chkpwd profile is actually for unix_chkpwd, fix this naming issue here
+    if [ "$filename" = unix-chkpwd ]
+    then filename=unix_chkpwd
+    fi
+
+    match_found=false
+    for target_dir in "${SEARCH_DIRS[@]}"; do
+        # Check if the file exists in the target directory
+        if [ -e "${target_dir}/${filename}" ]; then
+            match_found=true
+            break
+        fi
+    done
+
+    # If no match was found in any directory, perform deletion
+    if [ "$match_found" = false ]; then
+        echo "[DELETING] $profile"
+        rm "$profile"
+    fi
+
+done
+
+echo "Cleanup complete."


### PR DESCRIPTION
This speeds up boot time as we prevent many calls to apparmor_parser.

This patch is amended compared to the core26 counterpart, to provide the correct set of expected profiles (in this case, none). Those differ from base to base.